### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -29,7 +29,7 @@ library
                        Rasterific >= 0.2 && < 0.4,
                        FontyFruity >= 0.2 && < 0.4,
                        JuicyPixels >= 3.1.5 && < 3.2,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        mtl >= 2.1 && < 2.3,
                        statestack >= 0.2 && < 0.3,
                        data-default-class >= 0.0 && < 0.1,


### PR DESCRIPTION
Allow `diagrams-rasterific` to use the latest version of `lens` (4.5).
