### PR TITLE
Group opacity

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -27,7 +27,7 @@ library
                        diagrams-core >= 1.3 && < 1.4,
                        diagrams-lib >= 1.3 && < 1.4,
                        hashable >= 1.1 && < 1.3,
-                       Rasterific >= 0.5 && < 0.6,
+                       Rasterific >= 0.5.2 && < 0.6,
                        FontyFruity >= 0.5 && < 0.6,
                        JuicyPixels >= 3.1.5 && < 3.3,
                        lens >= 4.0 && < 4.9,

--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -32,7 +32,6 @@ library
                        JuicyPixels >= 3.1.5 && < 3.3,
                        lens >= 4.0 && < 4.9,
                        mtl >= 2.1 && < 2.3,
-                       statestack >= 0.2 && < 0.3,
                        data-default-class >= 0.0 && < 0.1,
                        containers >= 0.5 && < 0.6,
                        filepath >= 1.2 && < 1.5,

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -221,12 +221,11 @@ fromDashing (Dashing ds d) = (map realToFrac ds, d)
 
 fromFillRule :: FillRule -> R.FillMethod
 fromFillRule EvenOdd = R.FillEvenOdd
-fromFillRule _        = R.FillWinding
+fromFillRule _       = R.FillWinding
 
 -- | Get an accumulated style attribute from the render monad state.
 getStyleAttrib :: AttributeClass a => (a -> b) -> RenderM n (Maybe b)
 getStyleAttrib f = (fmap f . getAttr) <$> ask
--- getStyleAttrib f = (fmap f . getAttr) <$> use accumStyle
 
 getStyleAttribN :: AttributeClass (a n) => (a n -> b) -> RenderM n (Maybe b)
 getStyleAttribN = getStyleAttrib
@@ -239,9 +238,9 @@ rasterificColor c o = PixelRGBA8 r g b a
     int x = round (255 * x)
 
 rasterificSpreadMethod :: SpreadMethod -> R.SamplerRepeat
-rasterificSpreadMethod GradPad      = R.SamplerPad
-rasterificSpreadMethod GradReflect  = R.SamplerReflect
-rasterificSpreadMethod GradRepeat   = R.SamplerRepeat
+rasterificSpreadMethod GradPad     = R.SamplerPad
+rasterificSpreadMethod GradReflect = R.SamplerReflect
+rasterificSpreadMethod GradRepeat  = R.SamplerRepeat
 
 rasterificStops :: TypeableFloat n => [GradientStop n] -> Gradient PixelRGBA8
 rasterificStops = map fromStop

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -164,7 +164,7 @@ runRenderM :: Typeable n => RenderM n a -> RenderR a
 runRenderM = flip evalStateT def
 
 -- | Map the underlying monad of 'StateT'. Any changes to the state in
---   @StateT s m a@ are ingnored ignored.
+--   @StateT s m a@ are ignored.
 liftMap :: (Monad m, Monad n) => (m a -> n b) -> StateT s m a -> StateT s n b
 liftMap f sma = StateT $ \s -> do
   let ma = evalStateT sma s

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -198,7 +198,7 @@ toRender = fromRTree
       fromRTree (Node n rs) = case n of
         RPrim p                 -> render Rasterific p
         RStyle sty'             -> R $ do
-          sty <- accumStyle <<>= sty'
+          sty <- accumStyle <<<>= sty'
           aStyle <- use accumStyle
           let R r = F.foldMap fromRTree rs
               m   = evalStateT r (RasterificState aStyle)

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -198,11 +198,13 @@ toRender = fromRTree
       fromRTree (Node n rs) = case n of
         RPrim p                 -> render Rasterific p
         RStyle sty'             -> R $ do
+          -- mappend new state and retrieve old state
           sty <- accumStyle <<<>= sty'
           aStyle <- use accumStyle
           let R r = F.foldMap fromRTree rs
               m   = evalStateT r (RasterificState aStyle)
           clip sty m
+          -- restore the old state
           accumStyle .= sty
         RAnnot (OpacityGroup x) -> R $ liftMap (R.withGroupOpacity (round $ 255 * x)) r
         _                       -> R r

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -174,9 +174,10 @@ fromRTree (Node n rs) = case n of
 
 -- | Clip a render using the Clip from the style.
 clip :: TypeableFloat n => Style V2 n -> RenderM n () -> RenderM n ()
-clip (view _clip -> clips) r
-  | null clips = r
-  | otherwise  = mapReaderT (R.withClipping (R.fill $ map renderPath clips)) r
+clip sty r = go (sty ^. _clip)
+  where
+    go []     = r
+    go (p:ps) = mapReaderT (R.withClipping $ R.fill (renderPath p)) (go ps)
 
 runR :: Render Rasterific V2 n -> RenderM n ()
 runR (R r) = r

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -85,8 +85,6 @@ import           Diagrams.Core.Types
 
 import           Diagrams.Prelude                    hiding (opacity, local)
 import           Diagrams.TwoD.Adjust                (adjustDia2D)
-import           Diagrams.TwoD.Attributes            (splitTextureFills)
-import           Diagrams.TwoD.Path                  (getFillRule)
 import           Diagrams.TwoD.Text                  hiding (Font)
 
 import           Codec.Picture
@@ -112,8 +110,7 @@ import           Control.Monad.Reader
 import qualified Data.ByteString.Lazy                as L (writeFile)
 import qualified Data.Foldable                       as F
 import           Data.Hashable                       (Hashable (..))
-import           Data.Maybe                          (fromJust, fromMaybe,
-                                                      isJust)
+import           Data.Maybe                          (fromMaybe)
 import           Data.Tree
 import           Data.Typeable
 import           Data.Word                           (Word8)
@@ -161,21 +158,19 @@ instance TypeableFloat n => Backend Rasterific V2 n where
   renderRTree _ opts t =
     R.renderDrawing (round w) (round h) bgColor r
     where
-      r       = runRenderM . runR . toRender $ t
+      r       = runRenderM . runR . fromRTree $ t
       V2 w h  = specToSize 100 (opts^.sizeSpec)
       bgColor = PixelRGBA8 0 0 0 0
 
   adjustDia c opts d = adjustDia2D sizeSpec c opts (d # reflectY)
 
-toRender :: TypeableFloat n => RTree Rasterific V2 n Annotation -> Render Rasterific V2 n
-toRender = fromRTree . splitTextureFills
-  where
-    fromRTree (Node n rs) = case n of
-      RPrim p                 -> render Rasterific p
-      RStyle sty              -> R $ clip sty (local (<> sty) r)
-      RAnnot (OpacityGroup x) -> R $ mapReaderT (R.withGroupOpacity (round $ 255 * x)) r
-      _                       -> R r
-      where R r = F.foldMap fromRTree rs
+fromRTree :: TypeableFloat n => RTree Rasterific V2 n Annotation -> Render Rasterific V2 n
+fromRTree (Node n rs) = case n of
+  RPrim p                 -> render Rasterific p
+  RStyle sty              -> R $ clip sty (local (<> sty) r)
+  RAnnot (OpacityGroup x) -> R $ mapReaderT (R.withGroupOpacity (round $ 255 * x)) r
+  _                       -> R r
+  where R r = F.foldMap fromRTree rs
 
 -- | Clip a render using the Clip from the style.
 clip :: TypeableFloat n => Style V2 n -> RenderM n () -> RenderM n ()
@@ -198,13 +193,12 @@ sizeSpec = lens _sizeSpec (\o s -> o {_sizeSpec = s})
 
 rasterificStrokeStyle :: TypeableFloat n => Style v n
                      -> (n, R.Join, (R.Cap, R.Cap), Maybe (R.DashPattern, n))
-rasterificStrokeStyle s = (strokeWidth, strokeJoin, strokeCaps, strokeDash)
+rasterificStrokeStyle s = (strokeWidth, strokeJoin, (strokeCap, strokeCap), strokeDash)
   where
-    strokeWidth = fromMaybe 1 $ getLineWidth <$> getAttr s
-    strokeJoin = fromMaybe (R.JoinMiter 0) (fromLineJoin . getLineJoin <$> getAttr s)
-    strokeCaps = (strokeCap, strokeCap)
-    strokeCap  = fromMaybe (R.CapStraight 0) (fromLineCap . getLineCap <$> getAttr s)
-    strokeDash = fromDashing . getDashing <$> getAttr s
+    strokeWidth = views _lineWidthU (fromMaybe 1) s
+    strokeJoin  = views _lineJoin   fromLineJoin s
+    strokeCap   = views _lineCap    fromLineCap s
+    strokeDash  = views _dashingU   (fmap fromDashing) s
 
 fromLineCap :: LineCap -> R.Cap
 fromLineCap LineCapButt   = R.CapStraight 0
@@ -222,13 +216,6 @@ fromDashing (Dashing ds d) = (map realToFrac ds, d)
 fromFillRule :: FillRule -> R.FillMethod
 fromFillRule EvenOdd = R.FillEvenOdd
 fromFillRule _       = R.FillWinding
-
--- | Get an accumulated style attribute from the render monad state.
-getStyleAttrib :: AttributeClass a => (a -> b) -> RenderM n (Maybe b)
-getStyleAttrib f = (fmap f . getAttr) <$> ask
-
-getStyleAttribN :: AttributeClass (a n) => (a n -> b) -> RenderM n (Maybe b)
-getStyleAttribN = getStyleAttrib
 
 rasterificColor :: SomeColor -> Double -> PixelRGBA8
 rasterificColor c o = PixelRGBA8 r g b a
@@ -331,14 +318,15 @@ mkStroke (realToFrac -> l) j c d primList =
 
 instance TypeableFloat n => Renderable (Path V2 n) Rasterific where
   render _ p = R $ do
-    f <- getStyleAttribN getFillTexture
-    s <- fromMaybe (solid black) <$> getStyleAttribN getLineTexture
-    o <- fromMaybe 1 <$> getStyleAttrib getOpacity
-    r <- fromMaybe Winding <$> getStyleAttrib getFillRule
     sty <- ask
+    let f = sty ^. _fillTexture
+        s = sty ^. _lineTexture
+        o = sty ^. _opacity
+        r = sty ^. _fillRule
 
-    let (l, j, c, d) = rasterificStrokeStyle sty
-        rule = fromFillRule r
+        (l, j, c, d) = rasterificStrokeStyle sty
+        canFill      = anyOf (_head . located) isLoop p && (f ^? _AC) /= Just transparent
+        rule         = fromFillRule r
 
         -- For stroking we need to keep all of the contours separate.
         primList = renderPath p
@@ -346,8 +334,9 @@ instance TypeableFloat n => Renderable (Path V2 n) Rasterific where
         -- For filling we need to concatenate them into a flat list.
         prms = concat primList
 
-    when (isJust f) $ liftR (R.withTexture (rasterificTexture (fromJust f) o)
-                    $ R.fillWithMethod rule prms)
+    when canFill $
+      liftR (R.withTexture (rasterificTexture f o) $ R.fillWithMethod rule prms)
+
     liftR (R.withTexture (rasterificTexture s o) $ mkStroke l j c d primList)
 
 -- read only of static data (safe)
@@ -389,11 +378,11 @@ textBox f p s = (_xMax bb - _xMin bb, _yMax bb - _yMin bb)
 
 instance TypeableFloat n => Renderable (Text n) Rasterific where
   render _ (Text tr al str) = R $ do
-    fs      <- fromMaybe 12 <$> getStyleAttribN getFontSize
-    slant   <- fromMaybe FontSlantNormal <$> getStyleAttrib getFontSlant
-    fw      <- fromMaybe FontWeightNormal <$> getStyleAttrib getFontWeight
-    f       <- fromMaybe (solid black) <$> getStyleAttribN getFillTexture
-    o       <- fromMaybe 1 <$> getStyleAttrib getOpacity
+    fs    <- views _fontSizeU (fromMaybe 12)
+    slant <- view _fontSlant
+    fw    <- view _fontWeight
+    f     <- view _fillTexture
+    o     <- view _opacity
     let fColor = rasterificTexture f o
         fs'          = R.PointSize (realToFrac fs)
         fnt          = fromFontStyle slant fw


### PR DESCRIPTION
Group opacity for rasterific. This requires `Rasterific-0.5.2`.

The new `withGroupOpacity` function acts on `Drawing px ()` and since we have `StateT (RasterificState n) (Drawing PixelRGBA8)` it's not easy to apply. I made a `liftMap` function that ignores any state changes, but this should be OK since we revert the state anyway, but I'm not sure about it.

Also ditched `statestack` because it was making things more complicated.

