### PR TITLE
Bumping Rasterific dependency

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -29,7 +29,7 @@ library
                        diagrams-core >= 1.3 && < 1.4,
                        diagrams-lib >= 1.3 && < 1.4,
                        hashable >= 1.1 && < 1.3,
-                       Rasterific >= 0.5.2 && < 0.6,
+                       Rasterific >= 0.5.2 && < 0.7,
                        FontyFruity >= 0.5 && < 0.6,
                        JuicyPixels >= 3.1.5 && < 3.3,
                        lens >= 4.0 && < 4.10,


### PR DESCRIPTION
I will release soon a new version of Rasterific with a new feature you may find handy:

  * PDF export (without image handling for now, will land in a minor).

I've succesfully compiled diagrams-rasterific 1.3.1.0 with Rasterific 0.6