### PR TITLE
Embed font files

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -1,5 +1,5 @@
 name:                diagrams-rasterific
-version:             1.3.1.2
+version:             1.3.1.8
 synopsis:            Rasterific backend for diagrams.
 description:         A full-featured backend for rendering
                      diagrams using the Rasterific rendering engine.
@@ -38,7 +38,8 @@ library
                        containers >= 0.5 && < 0.6,
                        filepath >= 1.2 && < 1.5,
                        optparse-applicative >= 0.10 && < 0.13,
-                       bytestring >= 0.9 && < 0.11
+                       bytestring >= 0.9 && < 0.11,
+                       file-embed >= 0.0 && < 0.1
 
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
diagrams-rasterific may be used in constrained environments where its font files are not available/accessible. This patch embeds font files into the binary to avoid unsafe file system accesses.

If this patch is not acceptable in the general case, we could use a Cabal flag to select between both methods instead.