### PR TITLE
Position text using baselineHeight instead of yMin

### DIFF
--- a/src/Diagrams/Backend/Rasterific/Text.hs
+++ b/src/Diagrams/Backend/Rasterific/Text.hs
@@ -36,7 +36,7 @@ import           Data.ByteString.Lazy      (fromStrict)
 --   the baseline.
 textBoundingBox :: RealFloat n => Font -> PointSize -> String -> BoundingBox V2 n
 textBoundingBox f p s = fromCorners
-                        (mkP2 (2*r2f _xMin bb)              (r2f _yMin bb))
+                        (mkP2 (2*r2f _xMin bb)              (r2f _baselineHeight bb))
                         (mkP2 (r2f _xMax bb + r2f _xMin bb) (r2f _yMax bb))
   where
     r2f = fmap realToFrac


### PR DESCRIPTION
Follow-up to #21.

Please let me know if I misunderstood the issue. As I understand it, we want the bounding box of the text to extend from the baseline to the top of the text. (In other words, letters that extend below the baseline **should** extend outside the bounding box.) 