### PR TITLE
Pre-bumping for Rasterific 0.7

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -29,7 +29,7 @@ library
                        diagrams-core >= 1.3 && < 1.4,
                        diagrams-lib >= 1.3 && < 1.4,
                        hashable >= 1.1 && < 1.3,
-                       Rasterific >= 0.6.1 && < 0.7,
+                       Rasterific >= 0.6.1 && < 0.8,
                        FontyFruity >= 0.5 && < 0.6,
                        JuicyPixels >= 3.1.5 && < 3.3,
                        lens >= 4.0 && < 4.16,


### PR DESCRIPTION
Hi, I will soon release Rasterific 0.7 with a new feature, the gradient mesh. It's a huge enough modification to warrant a major version bump, which shouldn't impact you.