### PR TITLE
fix test compile (and add a line thickness test)

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -43,3 +43,13 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+
+test-suite test0
+  type:                exitcode-stdio-1.0
+  main-is:             test0.hs
+  hs-source-dirs:      test
+  build-depends:       base >= 4.2 && < 4.11,
+                       diagrams-rasterific,
+                       diagrams-core >= 1.4 && < 1.5,
+                       diagrams-lib >= 1.4 && < 1.5
+  ghc-options:         -Wall

--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -53,3 +53,13 @@ test-suite test0
                        diagrams-core >= 1.4 && < 1.5,
                        diagrams-lib >= 1.4 && < 1.5
   ghc-options:         -Wall
+
+test-suite test1
+  type:                exitcode-stdio-1.0
+  main-is:             test1.hs
+  hs-source-dirs:      test
+  build-depends:       base >= 4.2 && < 4.11,
+                       diagrams-rasterific,
+                       diagrams-core >= 1.4 && < 1.5,
+                       diagrams-lib >= 1.4 && < 1.5
+  ghc-options:         -Wall

--- a/test/test0.hs
+++ b/test/test0.hs
@@ -1,13 +1,14 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
-
 import           Diagrams.Prelude
 import           Diagrams.Backend.Rasterific
 
-dia :: Diagram B V2 Float
+dia :: Diagram B
 dia = circle 35 # fc red
    <> regPoly 16 200 # fc blue
    <> regPoly 5 400 # fc orange # rotateBy (1/6)
 
-sizeSpec = mkSizeSpec (Just 600) Nothing
+sizeSpec :: SizeSpec V2 Double
+sizeSpec = mkSizeSpec2D (Just 600) Nothing
 
-main = renderRasterific "test0.png" sizeSpec 255 dia --(dia # translateX 0 # translateY (-300))
+main :: IO ()
+main = renderRasterific "test0.png" sizeSpec dia
+  --(dia # translateX 0 # translateY (-300))

--- a/test/test1.hs
+++ b/test/test1.hs
@@ -1,0 +1,20 @@
+import           Diagrams.Prelude
+import           Diagrams.Backend.Rasterific
+
+dia :: Diagram B
+dia = bgFrame 1 white $
+  vsep 0.5
+    [ l # lw thick
+    , l # lw thin
+    , l # lwG 0
+    ]
+  where
+    l = stroke (straight unitX `at` origin)
+
+sizeSpec :: SizeSpec V2 Double
+sizeSpec = mkSizeSpec2D (Just 600) Nothing
+
+main :: IO ()
+main = do
+  renderRasterific "test1.png" sizeSpec dia
+  renderRasterific "test1.pdf" sizeSpec dia


### PR DESCRIPTION
I did this to track down #43, which has since been fixed in Rasterific proper: https://github.com/Twinside/Rasterific/pull/40

Compiling these as "tests" doesn't really make that much sense since they can't fail, but at least it makes sure they're compiled and kept up to date? Of course also feel free to just take the fixes to test0.hs, not sure how useful it is to keep test1.hs around.