### PR TITLE
an attempt at fixing PDF output sizing

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -65,3 +65,14 @@ test-suite test-widths
                        diagrams-lib >= 1.4 && < 1.5
   ghc-options:         -Wall
   default-language:    Haskell2010
+
+test-suite test-size
+  type:                exitcode-stdio-1.0
+  main-is:             test-size.hs
+  hs-source-dirs:      test
+  build-depends:       base >= 4.2 && < 4.12,
+                       diagrams-rasterific,
+                       diagrams-core >= 1.4 && < 1.5,
+                       diagrams-lib >= 1.4 && < 1.5
+  ghc-options:         -Wall
+  default-language:    Haskell2010

--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -44,9 +44,9 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall
 
-test-suite test0
+test-suite test-render
   type:                exitcode-stdio-1.0
-  main-is:             test0.hs
+  main-is:             test-render.hs
   hs-source-dirs:      test
   build-depends:       base >= 4.2 && < 4.12,
                        diagrams-rasterific,
@@ -55,9 +55,9 @@ test-suite test0
   ghc-options:         -Wall
   default-language:    Haskell2010
 
-test-suite test1
+test-suite test-widths
   type:                exitcode-stdio-1.0
-  main-is:             test1.hs
+  main-is:             test-widths.hs
   hs-source-dirs:      test
   build-depends:       base >= 4.2 && < 4.12,
                        diagrams-rasterific,

--- a/src/Diagrams/Backend/Rasterific.hs
+++ b/src/Diagrams/Backend/Rasterific.hs
@@ -448,7 +448,21 @@ renderRasterific outFile spec d =
     _      -> writePng outFile img
   where
     img = renderDia Rasterific (RasterificOptions spec) d
-    V2 w h = specToSize 100 spec
+    (w, h) = specToDims (aspectRatio d) spec
+
+aspectRatio :: (V a ~ V2, Enveloped a) => a -> N a
+aspectRatio d = h / w
+  where
+    V2 w h = boxExtents (boundingBox d)
+
+specToDims :: (Fractional a, Ord a) => a -> SizeSpec V2 a -> (a, a)
+specToDims ar s =
+  case getSpec s of
+    V2 (Just w) (Just h) -> (w, h)
+    V2 (Just w) Nothing  -> (w, ar * w)
+    V2 Nothing (Just h)  -> (h / ar, h)
+    V2 Nothing Nothing   -> (100, 100)
+
 
 -- | Render a 'Rasterific' diagram to an animated gif with the given
 --   size and uniform delay. Diagrams should be the same size.

--- a/test/test-render.hs
+++ b/test/test-render.hs
@@ -10,5 +10,4 @@ sizeSpec :: SizeSpec V2 Double
 sizeSpec = mkSizeSpec2D (Just 600) Nothing
 
 main :: IO ()
-main = renderRasterific "test0.png" sizeSpec dia
-  --(dia # translateX 0 # translateY (-300))
+main = renderRasterific "test-render.png" sizeSpec dia

--- a/test/test-size.hs
+++ b/test/test-size.hs
@@ -4,13 +4,13 @@ import           Diagrams.Backend.Rasterific
 {- non-square diagram should yield non-square output -}
 
 dia :: Diagram B
-dia = roundedRect 2 1 0.2 === strutY 0.2
+dia = ellipseXY 1 1.5
 
 sizeSpec :: SizeSpec V2 Double
-sizeSpec = mkSizeSpec2D (Just 600) Nothing
+sizeSpec = mkSizeSpec2D (Just 200) Nothing
 
 sizeSpecBoth :: SizeSpec V2 Double
-sizeSpecBoth = mkSizeSpec2D (Just 600) (Just 500)
+sizeSpecBoth = mkSizeSpec2D (Just 200) (Just 300)
 
 main :: IO ()
 main = do

--- a/test/test-size.hs
+++ b/test/test-size.hs
@@ -1,0 +1,20 @@
+import           Diagrams.Prelude
+import           Diagrams.Backend.Rasterific
+
+{- non-square diagram should yield non-square output -}
+
+dia :: Diagram B
+dia = roundedRect 2 1 0.2 === strutY 0.2
+
+sizeSpec :: SizeSpec V2 Double
+sizeSpec = mkSizeSpec2D (Just 600) Nothing
+
+sizeSpecBoth :: SizeSpec V2 Double
+sizeSpecBoth = mkSizeSpec2D (Just 600) (Just 500)
+
+main :: IO ()
+main = do
+  renderRasterific "test-size.png" sizeSpec dia
+  renderRasterific "test-size.pdf" sizeSpec dia
+  renderRasterific "test-size-both.png" sizeSpecBoth dia
+  renderRasterific "test-size-both.pdf" sizeSpecBoth dia

--- a/test/test-widths.hs
+++ b/test/test-widths.hs
@@ -16,5 +16,5 @@ sizeSpec = mkSizeSpec2D (Just 600) Nothing
 
 main :: IO ()
 main = do
-  renderRasterific "test1.png" sizeSpec dia
-  renderRasterific "test1.pdf" sizeSpec dia
+  renderRasterific "test-widths.png" sizeSpec dia
+  renderRasterific "test-widths.pdf" sizeSpec dia


### PR DESCRIPTION
I noticed that PDF outputs of non-square diagrams ended up as square PDFs, with extra white space at the bottom, when specifying the output width only as a size spec. In contrast, for PNGs, the result is a PNG of the specified width with an appropriate height that preserves the aspect ratio of the diagram.

There's a test in this PR which draws a non-square diagram. It also shows some weird behaviour for PNGs, I didn't really understand that part (or how using `specToSize` could ever really do the right thing...). And then there's a rather heavy-handed fix for the PDF sizing issue that should probably not be merged like this. I couldn't figure out how to make the functions in Diagrams.Size do anything useful here.