### PR TITLE
remove GHC 7.8.4 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: haskell
 
 env:
   matrix:
-    - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.3 CABALVER=1.22
     - GHCVER=8.0.2 CABALVER=1.24
     - GHCVER=8.2.2 CABALVER=2.0


### PR DESCRIPTION
It seems Rasterific-0.7.4 needs GHC 7.10.

Compare the build failure for https://github.com/diagrams/diagrams-rasterific/pull/53.