### PR TITLE
release version 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v1.4.2](https://github.com/diagrams/diagrams-rasterific/tree/v1.4.2) (2019-05-02)
+
+    - Add `renderPdfBS` to output PDF in-memory.
+
 ## [v1.4.1.1](https://github.com/diagrams/diagrams-rasterific/tree/v1.4.1.1) (2018-10-12)
 
 - Require `Rasterific-0.7.4` to

--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -1,5 +1,5 @@
 name:                diagrams-rasterific
-version:             1.4.1.1
+version:             1.4.2
 synopsis:            Rasterific backend for diagrams.
 description:         A full-featured backend for rendering
                      diagrams using the Rasterific rendering engine.


### PR DESCRIPTION
Not sure this is the right way to do this, but please consider this PR an attempt to

(a) suggest to release a new version that includes `renderPdfBS`
(b) see if this builds cleanly on travis

(My immediate goal is to resolve https://github.com/robx/puzzle-draw/issues/44, and be able to build via cabal/hackage again.)