### PR TITLE
include fonts in `extra-source-files` not `data-files`

### DIFF
--- a/diagrams-rasterific.cabal
+++ b/diagrams-rasterific.cabal
@@ -11,8 +11,7 @@ maintainer:          diagrams-discuss@googlegroups.com
 bug-reports:         http://github.com/diagrams/diagrams-rasterific/issues
 category:            Graphics
 build-type:          Simple
-data-files:          fonts/*.ttf
-extra-source-files:  README.md, CHANGELOG.md
+extra-source-files:  README.md, CHANGELOG.md, fonts/*.ttf
 tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
 cabal-version:       1.18
 Source-repository head


### PR DESCRIPTION
They are needed at compile time, not at runtime.

I think when the fonts were added to `data-files`, they were loaded at runtime, with `getDataFileName`.  Now they are loaded with TH at compile time.  I've tested that with this change, the fonts are still included in the `sdist` tarball, and checked that `getDataFileName` no longer appears in this code.